### PR TITLE
Fix Spotify auth page CONFIG redeclaration error

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -197,539 +197,541 @@
 
     <script src="config.js"></script>
     <script>
-        // Enhanced configuration with better error handling
-        const CONFIG = window.CONFIG;
+        (() => {
+            // Enhanced configuration with better error handling
+            const CONFIG = window.CONFIG;
 
-        if (!CONFIG) {
-            throw new Error('Configuration failed to load. Please verify config.js is available.');
-        }
-
-        class SpotifyAuth {
-            constructor() {
-                this.debugLog = [];
-                this.init();
-            }
-            
-            log(message, data = null) {
-                const timestamp = new Date().toISOString();
-                const logEntry = `[${timestamp}] ${message}`;
-                console.log(logEntry, data || '');
-                this.debugLog.push(logEntry + (data ? ` ${JSON.stringify(data)}` : ''));
-                this.updateDebugDisplay();
+            if (!CONFIG) {
+                throw new Error('Configuration failed to load. Please verify config.js is available.');
             }
 
-            getClientIdInfo() {
-                const rawValue = CONFIG.CLIENT_ID;
-                const value = typeof rawValue === 'string' ? rawValue.trim() : '';
-                const normalized = value.toUpperCase();
-                const placeholderTokens = ['{{', 'YOUR', 'REPLACE', 'ENTER', 'CLIENT_ID'];
-                const looksPlaceholder = placeholderTokens.some(token => normalized.includes(token));
-                const isPresent = value.length > 0;
-                const isValid = isPresent && !looksPlaceholder;
-                const snippet = isPresent ? (value.length <= 8 ? value : `${value.slice(0, 8)}...`) : '(missing)';
-
-                return {
-                    value,
-                    snippet,
-                    isValid
-                };
-            }
-
-            updateDebugDisplay() {
-                const debugInfo = document.getElementById('debugInfo');
-                if (debugInfo) {
-                    debugInfo.textContent = this.debugLog.join('\n');
-                    debugInfo.scrollTop = debugInfo.scrollHeight;
-                }
-            }
-            
-            init() {
-                this.log('SpotifyAuth initializing');
-                
-                // Enhanced environment check
-                this.checkEnvironment();
-                
-                // Check if returning from OAuth
-                if (window.location.search) {
-                    this.log('URL has search params, handling callback');
-                    this.handleCallback();
-                } else {
-                    this.log('No search params, setting up auth button');
-                    this.setupAuthButton();
+            class SpotifyAuth {
+                constructor() {
+                    this.debugLog = [];
+                    this.init();
                 }
                 
-                // Setup debug toggle
-                this.setupDebugToggle();
-            }
-            
-            checkEnvironment() {
-                const issues = [];
-                const clientIdInfo = this.getClientIdInfo();
-
-                // Check HTTPS requirement
-                if (location.protocol !== 'https:' && !CONFIG.IS_LOCAL) {
-                    issues.push('HTTPS required for production');
+                log(message, data = null) {
+                    const timestamp = new Date().toISOString();
+                    const logEntry = `[${timestamp}] ${message}`;
+                    console.log(logEntry, data || '');
+                    this.debugLog.push(logEntry + (data ? ` ${JSON.stringify(data)}` : ''));
+                    this.updateDebugDisplay();
                 }
 
-                // Check crypto API
-                if (!window.crypto || !window.crypto.subtle) {
-                    issues.push('Crypto API not available');
+                getClientIdInfo() {
+                    const rawValue = CONFIG.CLIENT_ID;
+                    const value = typeof rawValue === 'string' ? rawValue.trim() : '';
+                    const normalized = value.toUpperCase();
+                    const placeholderTokens = ['{{', 'YOUR', 'REPLACE', 'ENTER', 'CLIENT_ID'];
+                    const looksPlaceholder = placeholderTokens.some(token => normalized.includes(token));
+                    const isPresent = value.length > 0;
+                    const isValid = isPresent && !looksPlaceholder;
+                    const snippet = isPresent ? (value.length <= 8 ? value : `${value.slice(0, 8)}...`) : '(missing)';
+
+                    return {
+                        value,
+                        snippet,
+                        isValid
+                    };
                 }
 
-                // Check client ID
-                if (!clientIdInfo.isValid) {
-                    issues.push('Invalid CLIENT_ID configuration');
-                }
-
-                // Check redirect URI
-                try {
-                    new URL(CONFIG.AUTH_REDIRECT_URI);
-                } catch (e) {
-                    issues.push('Invalid redirect URI');
+                updateDebugDisplay() {
+                    const debugInfo = document.getElementById('debugInfo');
+                    if (debugInfo) {
+                        debugInfo.textContent = this.debugLog.join('\n');
+                        debugInfo.scrollTop = debugInfo.scrollHeight;
+                    }
                 }
                 
-                this.log('Environment check', {
-                    host: CONFIG.HOST,
-                    isLocal: CONFIG.IS_LOCAL,
-                    protocol: location.protocol,
-                    clientId: clientIdInfo.snippet,
-                    clientIdValid: clientIdInfo.isValid,
-                    redirectUri: CONFIG.AUTH_REDIRECT_URI,
-                    issues: issues
-                });
-
-                if (issues.length > 0) {
-                    this.showMessage(`Configuration issues: ${issues.join(', ')}`, 'error', true);
-                }
-            }
-            
-            setupAuthButton() {
-                const authButton = document.getElementById('authButton');
-                
-                // Remove any existing listeners
-                authButton.replaceWith(authButton.cloneNode(true));
-                const newButton = document.getElementById('authButton');
-                
-                newButton.addEventListener('click', (e) => {
-                    e.preventDefault();
-                    this.log('Auth button clicked');
-                    this.startAuth();
-                });
-                
-                this.log('Auth button setup complete');
-            }
-            
-            setupDebugToggle() {
-                const debugToggle = document.getElementById('debugToggle');
-                const debugInfo = document.getElementById('debugInfo');
-                
-                debugToggle.addEventListener('click', () => {
-                    const isVisible = debugInfo.style.display === 'block';
-                    debugInfo.style.display = isVisible ? 'none' : 'block';
-                    debugToggle.textContent = isVisible ? 'Show Debug Info' : 'Hide Debug Info';
-                });
-            }
-            
-            showMessage(text, type = 'error', showRetry = false) {
-                const messageEl = document.getElementById('message');
-                let messageHtml = text;
-                
-                if (showRetry) {
-                    messageHtml += '<br><button class="retry-button" onclick="location.reload()">Try Again</button>';
-                }
-                
-                messageEl.innerHTML = messageHtml;
-                messageEl.className = `message ${type}`;
-                
-                this.log(`Message shown: ${type}`, text);
-            }
-            
-            showLoading(show = true) {
-                const loading = document.getElementById('loading');
-                const authButton = document.getElementById('authButton');
-                
-                loading.style.display = show ? 'block' : 'none';
-                authButton.disabled = show;
-                
-                if (show) {
-                    authButton.textContent = 'Connecting...';
-                } else {
-                    authButton.textContent = 'Connect Spotify';
-                }
-                
-                this.log(`Loading state: ${show}`);
-            }
-            
-            // PKCE helpers with better error handling
-            generateCodeVerifier() {
-                try {
-                    const array = new Uint8Array(32);
-                    crypto.getRandomValues(array);
-                    return btoa(String.fromCharCode(...array))
-                        .replace(/\+/g, '-')
-                        .replace(/\//g, '_')
-                        .replace(/=/g, '');
-                } catch (error) {
-                    this.log('Failed to generate code verifier', error.message);
-                    // Fallback method
-                    return Math.random().toString(36).substring(2, 15) + 
-                           Math.random().toString(36).substring(2, 15);
-                }
-            }
-            
-            async generateCodeChallenge(verifier) {
-                try {
-                    const encoder = new TextEncoder();
-                    const data = encoder.encode(verifier);
-                    const digest = await crypto.subtle.digest('SHA-256', data);
-                    return btoa(String.fromCharCode(...new Uint8Array(digest)))
-                        .replace(/\+/g, '-')
-                        .replace(/\//g, '_')
-                        .replace(/=/g, '');
-                } catch (error) {
-                    this.log('Failed to generate code challenge', error.message);
-                    // Fallback: return verifier (less secure but works)
-                    return verifier;
-                }
-            }
-            
-            generateState() {
-                try {
-                    const array = new Uint8Array(16);
-                    crypto.getRandomValues(array);
-                    return btoa(String.fromCharCode(...array));
-                } catch (error) {
-                    this.log('Failed to generate state', error.message);
-                    return Math.random().toString(36).substring(2, 15);
-                }
-            }
-            
-            async startAuth() {
-                try {
-                    this.log('Starting authentication process');
-                    this.showLoading(true);
-
-                    // Check crypto API availability
-                    if (!window.crypto) {
-                        throw new Error('Crypto API not available. Please use a modern browser (Chrome, Firefox, Safari, Edge).');
+                init() {
+                    this.log('SpotifyAuth initializing');
+                    
+                    // Enhanced environment check
+                    this.checkEnvironment();
+                    
+                    // Check if returning from OAuth
+                    if (window.location.search) {
+                        this.log('URL has search params, handling callback');
+                        this.handleCallback();
+                    } else {
+                        this.log('No search params, setting up auth button');
+                        this.setupAuthButton();
                     }
                     
-                    // Preserve country parameter
-                    const urlParams = new URLSearchParams(window.location.search);
-                    const country = urlParams.get('country');
-                    this.log('Country parameter', country);
-
+                    // Setup debug toggle
+                    this.setupDebugToggle();
+                }
+                
+                checkEnvironment() {
+                    const issues = [];
                     const clientIdInfo = this.getClientIdInfo();
+
+                    // Check HTTPS requirement
+                    if (location.protocol !== 'https:' && !CONFIG.IS_LOCAL) {
+                        issues.push('HTTPS required for production');
+                    }
+
+                    // Check crypto API
+                    if (!window.crypto || !window.crypto.subtle) {
+                        issues.push('Crypto API not available');
+                    }
+
+                    // Check client ID
                     if (!clientIdInfo.isValid) {
-                        throw new Error('Spotify client ID is not configured correctly.');
+                        issues.push('Invalid CLIENT_ID configuration');
                     }
 
-                    // Generate PKCE parameters
-                    this.log('Generating PKCE parameters');
-                    const codeVerifier = this.generateCodeVerifier();
-                    const codeChallenge = await this.generateCodeChallenge(codeVerifier);
-                    const state = this.generateState();
-                    
-                    this.log('PKCE parameters generated', {
-                        verifierLength: codeVerifier.length,
-                        challengeLength: codeChallenge.length,
-                        stateLength: state.length
-                    });
-                    
-                    // Store PKCE parameters and country
-                    sessionStorage.setItem('code_verifier', codeVerifier);
-                    sessionStorage.setItem('oauth_state', state);
-                    if (country) {
-                        sessionStorage.setItem('auth_country', country);
+                    // Check redirect URI
+                    try {
+                        new URL(CONFIG.AUTH_REDIRECT_URI);
+                    } catch (e) {
+                        issues.push('Invalid redirect URI');
                     }
                     
-                    this.log('Stored session data');
-
-                    // Build authorization URL
-                    const params = new URLSearchParams({
-                        client_id: clientIdInfo.value,
-                        response_type: 'code',
-                        redirect_uri: CONFIG.AUTH_REDIRECT_URI,
-                        code_challenge_method: 'S256',
-                        code_challenge: codeChallenge,
-                        state: state,
-                        scope: CONFIG.SCOPES.join(' ')
-                    });
-                    
-                    const authUrl = `https://accounts.spotify.com/authorize?${params}`;
-
-                    this.log('Authorization URL built', {
-                        url: authUrl.substring(0, 100) + '...',
+                    this.log('Environment check', {
+                        host: CONFIG.HOST,
+                        isLocal: CONFIG.IS_LOCAL,
+                        protocol: location.protocol,
                         clientId: clientIdInfo.snippet,
+                        clientIdValid: clientIdInfo.isValid,
                         redirectUri: CONFIG.AUTH_REDIRECT_URI,
-                        scopes: CONFIG.SCOPES.length
+                        issues: issues
                     });
-                    
-                    // Add a delay to show loading state
-                    setTimeout(() => {
-                        this.log('Redirecting to Spotify authorization');
-                        window.location.href = authUrl;
-                    }, 500);
-                    
-                } catch (error) {
-                    this.log('Auth setup error', error.message);
-                    console.error('Auth setup error:', error);
-                    this.showMessage(`Authentication setup failed: ${error.message}`, 'error', true);
-                    this.showLoading(false);
+
+                    if (issues.length > 0) {
+                        this.showMessage(`Configuration issues: ${issues.join(', ')}`, 'error', true);
+                    }
                 }
-            }
-            
-            async handleCallback() {
-                try {
-                    this.log('Handling OAuth callback');
-                    this.showLoading(true);
+                
+                setupAuthButton() {
+                    const authButton = document.getElementById('authButton');
                     
-                    const urlParams = new URLSearchParams(window.location.search);
-                    const code = urlParams.get('code');
-                    const state = urlParams.get('state');
-                    const error = urlParams.get('error');
-                    const errorDescription = urlParams.get('error_description');
+                    // Remove any existing listeners
+                    authButton.replaceWith(authButton.cloneNode(true));
+                    const newButton = document.getElementById('authButton');
                     
-                    this.log('Callback parameters', {
-                        hasCode: !!code,
-                        hasState: !!state,
-                        error: error,
-                        errorDescription: errorDescription
+                    newButton.addEventListener('click', (e) => {
+                        e.preventDefault();
+                        this.log('Auth button clicked');
+                        this.startAuth();
                     });
                     
-                    // Handle OAuth errors with better messaging
-                    if (error) {
-                        let errorMessage = 'Authentication failed';
-                        
-                        switch (error) {
-                            case 'access_denied':
-                                errorMessage = 'Authorization was cancelled. You need to grant access to use the game.';
-                                break;
-                            case 'invalid_client':
-                                errorMessage = 'Application configuration error. Please contact support.';
-                                break;
-                            case 'invalid_request':
-                                errorMessage = 'Invalid authentication request. Please try again.';
-                                break;
-                            case 'server_error':
-                                errorMessage = 'Spotify server error. Please try again in a few moments.';
-                                break;
-                            default:
-                                errorMessage = errorDescription || `Authentication error: ${error}`;
+                    this.log('Auth button setup complete');
+                }
+                
+                setupDebugToggle() {
+                    const debugToggle = document.getElementById('debugToggle');
+                    const debugInfo = document.getElementById('debugInfo');
+                    
+                    debugToggle.addEventListener('click', () => {
+                        const isVisible = debugInfo.style.display === 'block';
+                        debugInfo.style.display = isVisible ? 'none' : 'block';
+                        debugToggle.textContent = isVisible ? 'Show Debug Info' : 'Hide Debug Info';
+                    });
+                }
+                
+                showMessage(text, type = 'error', showRetry = false) {
+                    const messageEl = document.getElementById('message');
+                    let messageHtml = text;
+                    
+                    if (showRetry) {
+                        messageHtml += '<br><button class="retry-button" onclick="location.reload()">Try Again</button>';
+                    }
+                    
+                    messageEl.innerHTML = messageHtml;
+                    messageEl.className = `message ${type}`;
+                    
+                    this.log(`Message shown: ${type}`, text);
+                }
+                
+                showLoading(show = true) {
+                    const loading = document.getElementById('loading');
+                    const authButton = document.getElementById('authButton');
+                    
+                    loading.style.display = show ? 'block' : 'none';
+                    authButton.disabled = show;
+                    
+                    if (show) {
+                        authButton.textContent = 'Connecting...';
+                    } else {
+                        authButton.textContent = 'Connect Spotify';
+                    }
+                    
+                    this.log(`Loading state: ${show}`);
+                }
+                
+                // PKCE helpers with better error handling
+                generateCodeVerifier() {
+                    try {
+                        const array = new Uint8Array(32);
+                        crypto.getRandomValues(array);
+                        return btoa(String.fromCharCode(...array))
+                            .replace(/\+/g, '-')
+                            .replace(/\//g, '_')
+                            .replace(/=/g, '');
+                    } catch (error) {
+                        this.log('Failed to generate code verifier', error.message);
+                        // Fallback method
+                        return Math.random().toString(36).substring(2, 15) + 
+                               Math.random().toString(36).substring(2, 15);
+                    }
+                }
+                
+                async generateCodeChallenge(verifier) {
+                    try {
+                        const encoder = new TextEncoder();
+                        const data = encoder.encode(verifier);
+                        const digest = await crypto.subtle.digest('SHA-256', data);
+                        return btoa(String.fromCharCode(...new Uint8Array(digest)))
+                            .replace(/\+/g, '-')
+                            .replace(/\//g, '_')
+                            .replace(/=/g, '');
+                    } catch (error) {
+                        this.log('Failed to generate code challenge', error.message);
+                        // Fallback: return verifier (less secure but works)
+                        return verifier;
+                    }
+                }
+                
+                generateState() {
+                    try {
+                        const array = new Uint8Array(16);
+                        crypto.getRandomValues(array);
+                        return btoa(String.fromCharCode(...array));
+                    } catch (error) {
+                        this.log('Failed to generate state', error.message);
+                        return Math.random().toString(36).substring(2, 15);
+                    }
+                }
+                
+                async startAuth() {
+                    try {
+                        this.log('Starting authentication process');
+                        this.showLoading(true);
+
+                        // Check crypto API availability
+                        if (!window.crypto) {
+                            throw new Error('Crypto API not available. Please use a modern browser (Chrome, Firefox, Safari, Edge).');
                         }
                         
-                        this.log('OAuth error', errorMessage);
-                        this.showMessage(errorMessage, 'error', true);
-                        this.clearCallbackUrl();
-                        return;
-                    }
-                    
-                    // Validate state parameter
-                    const storedState = sessionStorage.getItem('oauth_state');
-                    if (!state || state !== storedState) {
-                        this.log('State validation failed', {
-                            receivedState: state?.substring(0, 10) + '...',
-                            storedState: storedState?.substring(0, 10) + '...'
-                        });
-                        this.showMessage('Security validation failed. This may be a security issue or session timeout. Please start over.', 'error', true);
-                        this.clearSession();
-                        this.clearCallbackUrl();
-                        return;
-                    }
-                    
-                    // Check for authorization code
-                    if (!code) {
-                        this.log('No authorization code received');
-                        this.showMessage('No authorization code received from Spotify. Please try again.', 'error', true);
-                        this.clearCallbackUrl();
-                        return;
-                    }
-                    
-                    // Get stored code verifier
-                    const codeVerifier = sessionStorage.getItem('code_verifier');
-                    if (!codeVerifier) {
-                        this.log('No code verifier found');
-                        this.showMessage('Authentication session expired. Please start the login process again.', 'error', true);
-                        this.clearCallbackUrl();
-                        return;
-                    }
-                    
-                    this.log('Validation passed, exchanging code for tokens');
-                    
-                    // Exchange code for tokens
-                    await this.exchangeCodeForTokens(code, codeVerifier);
-                    
-                } catch (error) {
-                    this.log('Callback handling error', error.message);
-                    console.error('Callback handling error:', error);
-                    this.showMessage(`Authentication processing failed: ${error.message}`, 'error', true);
-                    this.showLoading(false);
-                }
-            }
-            
-            async exchangeCodeForTokens(code, codeVerifier) {
-                try {
-                    this.log('Making token exchange request');
-                    
-                    const requestBody = new URLSearchParams({
-                        client_id: CONFIG.CLIENT_ID,
-                        grant_type: 'authorization_code',
-                        code: code,
-                        redirect_uri: CONFIG.AUTH_REDIRECT_URI,
-                        code_verifier: codeVerifier
-                    });
-                    
-                    this.log('Token request body prepared');
-                    
-                    const response = await fetch('https://accounts.spotify.com/api/token', {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/x-www-form-urlencoded',
-                        },
-                        body: requestBody
-                    });
-                    
-                    this.log('Token response received', {
-                        status: response.status,
-                        statusText: response.statusText,
-                        ok: response.ok
-                    });
-                    
-                    if (!response.ok) {
-                        const errorData = await response.json().catch(() => ({}));
-                        let errorMessage = 'Failed to complete authentication';
+                        // Preserve country parameter
+                        const urlParams = new URLSearchParams(window.location.search);
+                        const country = urlParams.get('country');
+                        this.log('Country parameter', country);
+
+                        const clientIdInfo = this.getClientIdInfo();
+                        if (!clientIdInfo.isValid) {
+                            throw new Error('Spotify client ID is not configured correctly.');
+                        }
+
+                        // Generate PKCE parameters
+                        this.log('Generating PKCE parameters');
+                        const codeVerifier = this.generateCodeVerifier();
+                        const codeChallenge = await this.generateCodeChallenge(codeVerifier);
+                        const state = this.generateState();
                         
-                        this.log('Token exchange failed', {
+                        this.log('PKCE parameters generated', {
+                            verifierLength: codeVerifier.length,
+                            challengeLength: codeChallenge.length,
+                            stateLength: state.length
+                        });
+                        
+                        // Store PKCE parameters and country
+                        sessionStorage.setItem('code_verifier', codeVerifier);
+                        sessionStorage.setItem('oauth_state', state);
+                        if (country) {
+                            sessionStorage.setItem('auth_country', country);
+                        }
+                        
+                        this.log('Stored session data');
+
+                        // Build authorization URL
+                        const params = new URLSearchParams({
+                            client_id: clientIdInfo.value,
+                            response_type: 'code',
+                            redirect_uri: CONFIG.AUTH_REDIRECT_URI,
+                            code_challenge_method: 'S256',
+                            code_challenge: codeChallenge,
+                            state: state,
+                            scope: CONFIG.SCOPES.join(' ')
+                        });
+                        
+                        const authUrl = `https://accounts.spotify.com/authorize?${params}`;
+
+                        this.log('Authorization URL built', {
+                            url: authUrl.substring(0, 100) + '...',
+                            clientId: clientIdInfo.snippet,
+                            redirectUri: CONFIG.AUTH_REDIRECT_URI,
+                            scopes: CONFIG.SCOPES.length
+                        });
+                        
+                        // Add a delay to show loading state
+                        setTimeout(() => {
+                            this.log('Redirecting to Spotify authorization');
+                            window.location.href = authUrl;
+                        }, 500);
+                        
+                    } catch (error) {
+                        this.log('Auth setup error', error.message);
+                        console.error('Auth setup error:', error);
+                        this.showMessage(`Authentication setup failed: ${error.message}`, 'error', true);
+                        this.showLoading(false);
+                    }
+                }
+                
+                async handleCallback() {
+                    try {
+                        this.log('Handling OAuth callback');
+                        this.showLoading(true);
+                        
+                        const urlParams = new URLSearchParams(window.location.search);
+                        const code = urlParams.get('code');
+                        const state = urlParams.get('state');
+                        const error = urlParams.get('error');
+                        const errorDescription = urlParams.get('error_description');
+                        
+                        this.log('Callback parameters', {
+                            hasCode: !!code,
+                            hasState: !!state,
+                            error: error,
+                            errorDescription: errorDescription
+                        });
+                        
+                        // Handle OAuth errors with better messaging
+                        if (error) {
+                            let errorMessage = 'Authentication failed';
+                            
+                            switch (error) {
+                                case 'access_denied':
+                                    errorMessage = 'Authorization was cancelled. You need to grant access to use the game.';
+                                    break;
+                                case 'invalid_client':
+                                    errorMessage = 'Application configuration error. Please contact support.';
+                                    break;
+                                case 'invalid_request':
+                                    errorMessage = 'Invalid authentication request. Please try again.';
+                                    break;
+                                case 'server_error':
+                                    errorMessage = 'Spotify server error. Please try again in a few moments.';
+                                    break;
+                                default:
+                                    errorMessage = errorDescription || `Authentication error: ${error}`;
+                            }
+                            
+                            this.log('OAuth error', errorMessage);
+                            this.showMessage(errorMessage, 'error', true);
+                            this.clearCallbackUrl();
+                            return;
+                        }
+                        
+                        // Validate state parameter
+                        const storedState = sessionStorage.getItem('oauth_state');
+                        if (!state || state !== storedState) {
+                            this.log('State validation failed', {
+                                receivedState: state?.substring(0, 10) + '...',
+                                storedState: storedState?.substring(0, 10) + '...'
+                            });
+                            this.showMessage('Security validation failed. This may be a security issue or session timeout. Please start over.', 'error', true);
+                            this.clearSession();
+                            this.clearCallbackUrl();
+                            return;
+                        }
+                        
+                        // Check for authorization code
+                        if (!code) {
+                            this.log('No authorization code received');
+                            this.showMessage('No authorization code received from Spotify. Please try again.', 'error', true);
+                            this.clearCallbackUrl();
+                            return;
+                        }
+                        
+                        // Get stored code verifier
+                        const codeVerifier = sessionStorage.getItem('code_verifier');
+                        if (!codeVerifier) {
+                            this.log('No code verifier found');
+                            this.showMessage('Authentication session expired. Please start the login process again.', 'error', true);
+                            this.clearCallbackUrl();
+                            return;
+                        }
+                        
+                        this.log('Validation passed, exchanging code for tokens');
+                        
+                        // Exchange code for tokens
+                        await this.exchangeCodeForTokens(code, codeVerifier);
+                        
+                    } catch (error) {
+                        this.log('Callback handling error', error.message);
+                        console.error('Callback handling error:', error);
+                        this.showMessage(`Authentication processing failed: ${error.message}`, 'error', true);
+                        this.showLoading(false);
+                    }
+                }
+                
+                async exchangeCodeForTokens(code, codeVerifier) {
+                    try {
+                        this.log('Making token exchange request');
+                        
+                        const requestBody = new URLSearchParams({
+                            client_id: CONFIG.CLIENT_ID,
+                            grant_type: 'authorization_code',
+                            code: code,
+                            redirect_uri: CONFIG.AUTH_REDIRECT_URI,
+                            code_verifier: codeVerifier
+                        });
+                        
+                        this.log('Token request body prepared');
+                        
+                        const response = await fetch('https://accounts.spotify.com/api/token', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/x-www-form-urlencoded',
+                            },
+                            body: requestBody
+                        });
+                        
+                        this.log('Token response received', {
                             status: response.status,
-                            error: errorData.error,
-                            description: errorData.error_description
+                            statusText: response.statusText,
+                            ok: response.ok
                         });
                         
-                        switch (errorData.error) {
-                            case 'invalid_grant':
-                                errorMessage = 'Authorization code expired. Please try logging in again.';
-                                break;
-                            case 'invalid_client':
-                                errorMessage = 'Application configuration error. Please contact support.';
-                                break;
-                            case 'invalid_request':
-                                errorMessage = 'Authentication request was invalid. Please try again.';
-                                break;
-                            default:
-                                errorMessage = errorData.error_description || `Authentication error: ${errorData.error || response.status}`;
+                        if (!response.ok) {
+                            const errorData = await response.json().catch(() => ({}));
+                            let errorMessage = 'Failed to complete authentication';
+                            
+                            this.log('Token exchange failed', {
+                                status: response.status,
+                                error: errorData.error,
+                                description: errorData.error_description
+                            });
+                            
+                            switch (errorData.error) {
+                                case 'invalid_grant':
+                                    errorMessage = 'Authorization code expired. Please try logging in again.';
+                                    break;
+                                case 'invalid_client':
+                                    errorMessage = 'Application configuration error. Please contact support.';
+                                    break;
+                                case 'invalid_request':
+                                    errorMessage = 'Authentication request was invalid. Please try again.';
+                                    break;
+                                default:
+                                    errorMessage = errorData.error_description || `Authentication error: ${errorData.error || response.status}`;
+                            }
+                            
+                            throw new Error(errorMessage);
                         }
                         
-                        throw new Error(errorMessage);
+                        const tokens = await response.json();
+                        
+                        this.log('Tokens received successfully', {
+                            hasAccessToken: !!tokens.access_token,
+                            hasRefreshToken: !!tokens.refresh_token,
+                            expiresIn: tokens.expires_in
+                        });
+                        
+                        // Validate token response
+                        if (!tokens.access_token) {
+                            throw new Error('Invalid token response from Spotify');
+                        }
+                        
+                        // Calculate expiration time
+                        const expiresAt = Date.now() + (tokens.expires_in * 1000);
+                        
+                        // Store tokens securely
+                        sessionStorage.setItem('access_token', tokens.access_token);
+                        if (tokens.refresh_token) {
+                            sessionStorage.setItem('refresh_token', tokens.refresh_token);
+                        }
+                        sessionStorage.setItem('expires_at', expiresAt.toString());
+                        
+                        // Generate bootstrap nonce for additional security
+                        const bootstrapNonce = this.generateState();
+                        sessionStorage.setItem('bootstrap_nonce', bootstrapNonce);
+                        
+                        // Clean up OAuth session data
+                        sessionStorage.removeItem('code_verifier');
+                        sessionStorage.removeItem('oauth_state');
+                        
+                        // Prepare navigation with preserved country
+                        const country = sessionStorage.getItem('auth_country');
+                        sessionStorage.removeItem('auth_country');
+                        
+                        let gameUrl = `${CONFIG.GAME_URL}?bootstrap=${bootstrapNonce}`;
+                        if (country) {
+                            gameUrl += `&country=${encodeURIComponent(country)}`;
+                        }
+                        
+                        this.log('Preparing redirect to game', {
+                            gameUrl: gameUrl.substring(0, 50) + '...'
+                        });
+                        
+                        this.showMessage('Authentication successful! Redirecting to game...', 'success');
+                        
+                        // Navigate to game with a slight delay for user feedback
+                        setTimeout(() => {
+                            this.log('Redirecting to game');
+                            window.location.href = gameUrl;
+                        }, 1500);
+                        
+                    } catch (error) {
+                        this.log('Token exchange error', error.message);
+                        console.error('Token exchange error:', error);
+                        this.showMessage(error.message || 'Failed to complete authentication', 'error', true);
+                        this.clearSession();
+                        this.showLoading(false);
                     }
-                    
-                    const tokens = await response.json();
-                    
-                    this.log('Tokens received successfully', {
-                        hasAccessToken: !!tokens.access_token,
-                        hasRefreshToken: !!tokens.refresh_token,
-                        expiresIn: tokens.expires_in
-                    });
-                    
-                    // Validate token response
-                    if (!tokens.access_token) {
-                        throw new Error('Invalid token response from Spotify');
-                    }
-                    
-                    // Calculate expiration time
-                    const expiresAt = Date.now() + (tokens.expires_in * 1000);
-                    
-                    // Store tokens securely
-                    sessionStorage.setItem('access_token', tokens.access_token);
-                    if (tokens.refresh_token) {
-                        sessionStorage.setItem('refresh_token', tokens.refresh_token);
-                    }
-                    sessionStorage.setItem('expires_at', expiresAt.toString());
-                    
-                    // Generate bootstrap nonce for additional security
-                    const bootstrapNonce = this.generateState();
-                    sessionStorage.setItem('bootstrap_nonce', bootstrapNonce);
-                    
-                    // Clean up OAuth session data
+                }
+                
+                clearSession() {
+                    this.log('Clearing session storage');
                     sessionStorage.removeItem('code_verifier');
                     sessionStorage.removeItem('oauth_state');
-                    
-                    // Prepare navigation with preserved country
-                    const country = sessionStorage.getItem('auth_country');
                     sessionStorage.removeItem('auth_country');
-                    
-                    let gameUrl = `${CONFIG.GAME_URL}?bootstrap=${bootstrapNonce}`;
-                    if (country) {
-                        gameUrl += `&country=${encodeURIComponent(country)}`;
-                    }
-                    
-                    this.log('Preparing redirect to game', {
-                        gameUrl: gameUrl.substring(0, 50) + '...'
-                    });
-                    
-                    this.showMessage('Authentication successful! Redirecting to game...', 'success');
-                    
-                    // Navigate to game with a slight delay for user feedback
-                    setTimeout(() => {
-                        this.log('Redirecting to game');
-                        window.location.href = gameUrl;
-                    }, 1500);
-                    
-                } catch (error) {
-                    this.log('Token exchange error', error.message);
-                    console.error('Token exchange error:', error);
-                    this.showMessage(error.message || 'Failed to complete authentication', 'error', true);
-                    this.clearSession();
-                    this.showLoading(false);
+                    sessionStorage.removeItem('access_token');
+                    sessionStorage.removeItem('refresh_token');
+                    sessionStorage.removeItem('expires_at');
+                    sessionStorage.removeItem('bootstrap_nonce');
+                }
+                
+                clearCallbackUrl() {
+                    this.log('Clearing callback URL');
+                    const url = new URL(window.location);
+                    url.search = '';
+                    window.history.replaceState({}, document.title, url.toString());
                 }
             }
-            
-            clearSession() {
-                this.log('Clearing session storage');
-                sessionStorage.removeItem('code_verifier');
-                sessionStorage.removeItem('oauth_state');
-                sessionStorage.removeItem('auth_country');
-                sessionStorage.removeItem('access_token');
-                sessionStorage.removeItem('refresh_token');
-                sessionStorage.removeItem('expires_at');
-                sessionStorage.removeItem('bootstrap_nonce');
-            }
-            
-            clearCallbackUrl() {
-                this.log('Clearing callback URL');
-                const url = new URL(window.location);
-                url.search = '';
-                window.history.replaceState({}, document.title, url.toString());
-            }
-        }
 
-        // Initialize the auth system with better error handling
-        document.addEventListener('DOMContentLoaded', () => {
-            try {
-                new SpotifyAuth();
-            } catch (error) {
-                console.error('Failed to initialize auth:', error);
-                document.getElementById('message').innerHTML = 
-                    `<div class="message error">Failed to initialize: ${error.message}<br><button class="retry-button" onclick="location.reload()">Reload Page</button></div>`;
-            }
-        });
+            // Initialize the auth system with better error handling
+            document.addEventListener('DOMContentLoaded', () => {
+                try {
+                    new SpotifyAuth();
+                } catch (error) {
+                    console.error('Failed to initialize auth:', error);
+                    document.getElementById('message').innerHTML = 
+                        `<div class="message error">Failed to initialize: ${error.message}<br><button class="retry-button" onclick="location.reload()">Reload Page</button></div>`;
+                }
+            });
 
-        // Global error handler
-        window.addEventListener('error', (event) => {
-            console.error('Global error:', event.error);
-            const messageEl = document.getElementById('message');
-            if (messageEl && !messageEl.innerHTML) {
-                messageEl.innerHTML = `<div class="message error">JavaScript error: ${event.error?.message || 'Unknown error'}<br><button class="retry-button" onclick="location.reload()">Reload Page</button></div>`;
-            }
-        });
+            // Global error handler
+            window.addEventListener('error', (event) => {
+                console.error('Global error:', event.error);
+                const messageEl = document.getElementById('message');
+                if (messageEl && !messageEl.innerHTML) {
+                    messageEl.innerHTML = `<div class="message error">JavaScript error: ${event.error?.message || 'Unknown error'}<br><button class="retry-button" onclick="location.reload()">Reload Page</button></div>`;
+                }
+            });
 
-        // Unhandled promise rejection handler
-        window.addEventListener('unhandledrejection', (event) => {
-            console.error('Unhandled promise rejection:', event.reason);
-            const messageEl = document.getElementById('message');
-            if (messageEl && !messageEl.innerHTML) {
-                messageEl.innerHTML = `<div class="message error">Promise error: ${event.reason?.message || 'Unknown error'}<br><button class="retry-button" onclick="location.reload()">Reload Page</button></div>`;
-            }
-        });
+            // Unhandled promise rejection handler
+            window.addEventListener('unhandledrejection', (event) => {
+                console.error('Unhandled promise rejection:', event.reason);
+                const messageEl = document.getElementById('message');
+                if (messageEl && !messageEl.innerHTML) {
+                    messageEl.innerHTML = `<div class="message error">Promise error: ${event.reason?.message || 'Unknown error'}<br><button class="retry-button" onclick="location.reload()">Reload Page</button></div>`;
+                }
+            });
+        })();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap the `auth.html` script in an IIFE so it can safely read `window.CONFIG`
- restore the authentication flow so the Connect Spotify button redirects correctly

## Testing
- Manual Playwright verification of `auth.html` redirects to Spotify

------
https://chatgpt.com/codex/tasks/task_e_68ca9a8659e4832eb0a800ae2a8fe0c1