### PR TITLE
Load charts from JSON files

### DIFF
--- a/charts/track1.json
+++ b/charts/track1.json
@@ -1,0 +1,95 @@
+{
+  "title": "Locked Track 1",
+  "artist": "Demo Composer",
+  "defaultDifficulty": "NORMAL",
+  "zeroIndexed": true,
+  "metadata": {
+    "bpm": 120,
+    "description": "Sample MIDI-converted chart for testing"
+  },
+  "difficulties": {
+    "EASY": {
+      "lanes": 4,
+      "notes": [
+        { "time": 2000, "lane": 0, "type": "tap" },
+        { "time": 3500, "lane": 2, "type": "tap" },
+        { "time": 5000, "lane": 1, "type": "tap" },
+        { "time": 6500, "lane": 3, "type": "tap" },
+        { "time": 8000, "lane": 0, "type": "tap" },
+        { "time": 9500, "lane": 2, "type": "hold", "duration": 1500 },
+        { "time": 12000, "lane": 1, "type": "tap" },
+        { "time": 13500, "lane": 3, "type": "tap" },
+        { "time": 15000, "lane": 0, "type": "tap" }
+      ],
+      "metadata": {
+        "noteCount": 9
+      }
+    },
+    "NORMAL": {
+      "lanes": 4,
+      "notes": [
+        { "time": 1500, "lane": 0 },
+        { "time": 2250, "lane": 1 },
+        { "time": 3000, "lane": 2 },
+        { "time": 3750, "lane": 3 },
+        { "time": 4500, "lane": 0 },
+        { "time": 5250, "lane": 1 },
+        { "time": 6000, "lane": 2, "type": "hold", "duration": 1800 },
+        { "time": 8400, "lane": 3 },
+        { "time": 9150, "lane": 2 },
+        { "time": 9900, "lane": 1 },
+        { "time": 10650, "lane": 0 },
+        { "time": 11400, "lane": 3 },
+        { "time": 12150, "lane": 2 },
+        { "time": 12900, "lane": 1 },
+        { "time": 13650, "lane": 0 },
+        { "time": 14400, "lane": 3 },
+        { "time": 15150, "lane": 2 },
+        { "time": 15900, "lane": 1 },
+        { "time": 16650, "lane": 0 },
+        { "time": 17400, "lane": 3 }
+      ]
+    },
+    "HARD": {
+      "lanes": 4,
+      "notes": [
+        { "time": 1000, "lane": 0 },
+        { "time": 1450, "lane": 1 },
+        { "time": 1900, "lane": 2 },
+        { "time": 2350, "lane": 3 },
+        { "time": 2800, "lane": 1 },
+        { "time": 3250, "lane": 0 },
+        { "time": 3700, "lane": 2 },
+        { "time": 4150, "lane": 3 },
+        { "time": 4600, "lane": 0 },
+        { "time": 5050, "lane": 1 },
+        { "time": 5500, "lane": 2 },
+        { "time": 5950, "lane": 3 },
+        { "time": 6400, "lane": 0, "type": "hold", "duration": 2000 },
+        { "time": 8500, "lane": 1 },
+        { "time": 8950, "lane": 2 },
+        { "time": 9400, "lane": 3 },
+        { "time": 9850, "lane": 1 },
+        { "time": 10300, "lane": 0 },
+        { "time": 10750, "lane": 2 },
+        { "time": 11200, "lane": 3 },
+        { "time": 11650, "lane": 0 },
+        { "time": 12100, "lane": 1 },
+        { "time": 12550, "lane": 2 },
+        { "time": 13000, "lane": 3 },
+        { "time": 13450, "lane": 1 },
+        { "time": 13900, "lane": 0 },
+        { "time": 14350, "lane": 2 },
+        { "time": 14800, "lane": 3 },
+        { "time": 15250, "lane": 1 },
+        { "time": 15700, "lane": 0 },
+        { "time": 16150, "lane": 2 },
+        { "time": 16600, "lane": 3 },
+        { "time": 17050, "lane": 0 },
+        { "time": 17500, "lane": 1 },
+        { "time": 17950, "lane": 2 },
+        { "time": 18400, "lane": 3 }
+      ]
+    }
+  }
+}

--- a/charts/track2.json
+++ b/charts/track2.json
@@ -1,0 +1,102 @@
+{
+  "title": "Locked Track 2",
+  "artist": "Demo Composer",
+  "defaultDifficulty": "HARD",
+  "zeroIndexed": true,
+  "metadata": {
+    "bpm": 140,
+    "description": "Second sample MIDI-converted chart"
+  },
+  "difficulties": {
+    "EASY": {
+      "lanes": 4,
+      "notes": [
+        { "time": 1800, "lane": 1 },
+        { "time": 3200, "lane": 2 },
+        { "time": 4600, "lane": 3 },
+        { "time": 6000, "lane": 0 },
+        { "time": 7400, "lane": 1 },
+        { "time": 8800, "lane": 2 },
+        { "time": 10200, "lane": 3 },
+        { "time": 11600, "lane": 0 },
+        { "time": 13000, "lane": 2, "type": "hold", "duration": 1500 },
+        { "time": 15600, "lane": 1 }
+      ]
+    },
+    "NORMAL": {
+      "lanes": 4,
+      "notes": [
+        { "time": 1200, "lane": 0 },
+        { "time": 1800, "lane": 1 },
+        { "time": 2400, "lane": 2 },
+        { "time": 3000, "lane": 3 },
+        { "time": 3600, "lane": 0 },
+        { "time": 4200, "lane": 2 },
+        { "time": 4800, "lane": 1 },
+        { "time": 5400, "lane": 3 },
+        { "time": 6000, "lane": 0 },
+        { "time": 6600, "lane": 1 },
+        { "time": 7200, "lane": 2 },
+        { "time": 7800, "lane": 3 },
+        { "time": 8400, "lane": 0 },
+        { "time": 9000, "lane": 2 },
+        { "time": 9600, "lane": 1 },
+        { "time": 10200, "lane": 3 },
+        { "time": 10800, "lane": 0 },
+        { "time": 11400, "lane": 1 },
+        { "time": 12000, "lane": 2 },
+        { "time": 12600, "lane": 3 },
+        { "time": 13200, "lane": 0, "type": "hold", "duration": 1600 },
+        { "time": 15600, "lane": 1 },
+        { "time": 16200, "lane": 2 },
+        { "time": 16800, "lane": 3 }
+      ]
+    },
+    "HARD": {
+      "lanes": 4,
+      "notes": [
+        { "time": 800, "lane": 0 },
+        { "time": 1200, "lane": 1 },
+        { "time": 1600, "lane": 2 },
+        { "time": 2000, "lane": 3 },
+        { "time": 2400, "lane": 0 },
+        { "time": 2800, "lane": 1 },
+        { "time": 3200, "lane": 2 },
+        { "time": 3600, "lane": 3 },
+        { "time": 4000, "lane": 0 },
+        { "time": 4400, "lane": 1 },
+        { "time": 4800, "lane": 2 },
+        { "time": 5200, "lane": 3 },
+        { "time": 5600, "lane": 1 },
+        { "time": 6000, "lane": 0 },
+        { "time": 6400, "lane": 2 },
+        { "time": 6800, "lane": 3 },
+        { "time": 7200, "lane": 1 },
+        { "time": 7600, "lane": 0 },
+        { "time": 8000, "lane": 2 },
+        { "time": 8400, "lane": 3 },
+        { "time": 8800, "lane": 0 },
+        { "time": 9200, "lane": 1 },
+        { "time": 9600, "lane": 2 },
+        { "time": 10000, "lane": 3 },
+        { "time": 10400, "lane": 1 },
+        { "time": 10800, "lane": 0 },
+        { "time": 11200, "lane": 2 },
+        { "time": 11600, "lane": 3 },
+        { "time": 12000, "lane": 0 },
+        { "time": 12400, "lane": 1 },
+        { "time": 12800, "lane": 2 },
+        { "time": 13200, "lane": 3 },
+        { "time": 13600, "lane": 1 },
+        { "time": 14000, "lane": 0 },
+        { "time": 14400, "lane": 2 },
+        { "time": 14800, "lane": 3 },
+        { "time": 15200, "lane": 0, "type": "hold", "duration": 2000 },
+        { "time": 17800, "lane": 1 },
+        { "time": 18200, "lane": 2 },
+        { "time": 18600, "lane": 3 },
+        { "time": 19000, "lane": 0 }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add support for loading rhythm charts from pre-generated JSON files when available
- add validation and normalization helpers for JSON-based charts with difficulty fallbacks
- include example JSON charts for the locked MIDI tracks

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cdec256d74832eb98ee28fdba1bead