### PR TITLE
Fix Spotify playback errors and auto-calibration

### DIFF
--- a/rhythm.html
+++ b/rhythm.html
@@ -696,11 +696,14 @@
                     targetOffset = 15; // 15ms ahead to compensate for processing delay
                 } else {
                     // For other tracks, use audio analysis or default
-                    const track = await app.client.getCurrentPlaybackState();
-                    if (track && track.item) {
+                    const playbackState = await app.client.getPlaybackState();
+                    if (playbackState && playbackState.item) {
                         try {
-                            const features = await app.client.getAudioFeatures(track.item.id);
-                            const tempo = features.tempo || 120;
+                            const features = await app.client.getAudioFeatures(playbackState.item.id);
+                            const feature = Array.isArray(features?.audio_features)
+                                ? features.audio_features[0]
+                                : features;
+                            const tempo = feature?.tempo || 120;
                             
                             // Calculate offset based on tempo (slower songs need more lookahead)
                             if (tempo < 90) {


### PR DESCRIPTION
## Summary
- avoid JSON parse exceptions for Spotify responses that return plain text payloads
- fall back to returning raw text for non-JSON responses so playback skips can proceed
- repair the rhythm game's auto-calibration by using the correct playback API and handling audio-feature payloads

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf672759bc832eaeaf9dcddddd7b7c