### PR TITLE
Align locked track IDs with available MIDI charts

### DIFF
--- a/config.js
+++ b/config.js
@@ -27,15 +27,13 @@ export const config = {
     // Locked tracks for consistent gameplay
     LOCKED_TRACK_IDS: [
         '5FMyXeZ0reYloRTiCkPprT',  // Track 1 - Fixed
-        'lbjDy6IIerHFGZWKG0hno'   // Track 2 - Fixed
-    ], 
-    
+        '0YWmeJtd7Fp1tH3978qUIH'   // Track 2 - Fixed
+    ],
+
     // Pool of tracks for random third selection
     THIRD_TRACK_POOL: [
-        'lbjDy6IIerHFGZWKG0hno',  // Option 1
-        'lbjDy6IIerHFGZWKG0hno',  // Option 2
-        'lbjDy6IIerHFGZWKG0hno',  // Option 3
-        'lbjDy6IIerHFGZWKG0hno'   // Option 4
+        '5FMyXeZ0reYloRTiCkPprT',
+        '0YWmeJtd7Fp1tH3978qUIH'
     ],
     
     // Required Spotify scopes (exact string as specified)


### PR DESCRIPTION
## Summary
- update the locked track list to use the two tracks that have MIDI and JSON charts
- narrow the random third track pool to those same verified chart IDs to avoid unsupported selections

## Testing
- browser_container.run_playwright_script (local console log capture confirming Tracks with MIDI contains both locked IDs)

------
https://chatgpt.com/codex/tasks/task_e_68d1a4b68238832ebec08db35b57b491