### PR TITLE
Smooth note rendering and lane press feedback

### DIFF
--- a/rhythm.html
+++ b/rhythm.html
@@ -1271,7 +1271,7 @@
                 app.input.onLaneHit = (lane, inputTime) => {
                     const result = app.engine.handleLaneHit(lane, inputTime);
                     if (result && app.render) {
-                        app.render.showHitEffect(lane, result.hitType);
+                        app.render.showHitEffect(lane, result.hitType, result);
                     }
                 };
 


### PR DESCRIPTION
## Summary
- smooth note travel by caching render progress in the engine and easing it toward the target position
- add lane press state tracking so receptors glow and pulse when a hit or miss occurs
- surface hit details to the renderer so combo popups and hit effects trigger together

## Testing
- Not run (Spotify playback and rhythm flow depend on external services)

------
https://chatgpt.com/codex/tasks/task_e_68d8e41d8fd8832e923be0c472c8c961