### PR TITLE
Fix lane hit timing to trigger hit feedback

### DIFF
--- a/rhythm.html
+++ b/rhythm.html
@@ -1269,9 +1269,12 @@
         function setupEventHandlers() {
             if (app.input && app.engine) {
                 app.input.onLaneHit = (lane, inputTime) => {
-                    const result = app.engine.handleLaneHit(lane, inputTime);
+                    const timingAdjustedInput = Number.isFinite(inputTime)
+                        ? app.engine.getCurrentGameTime()
+                        : undefined;
+                    const result = app.engine.handleLaneHit(lane, timingAdjustedInput);
                     if (result && app.render) {
-                        app.render.showHitEffect(lane, result.hitType);
+                        app.render.showHitEffect(lane, result.hitType, result);
                     }
                 };
 


### PR DESCRIPTION
## Summary
- convert lane hit callbacks to use the engine's synchronized game clock so hits register

## Testing
- Not run (Spotify playback requires external services)

------
https://chatgpt.com/codex/tasks/task_e_68d8e41d8fd8832e923be0c472c8c961